### PR TITLE
Optimize `ObjectBag#_grow`

### DIFF
--- a/entities.mod/src/entity_bag.bmx
+++ b/entities.mod/src/entity_bag.bmx
@@ -309,16 +309,8 @@ Type EntityBag
 		' Use default new size if none set
 		If newCapacity < 0 Then newCapacity = ((Self._objects.Length * 3) / 2) + 1
 
-		' Create copy of current objects
-		Local oldObjects:Entity[] = Self._objects
-
-		' Recreate array with new size
-		Self._objects = New Entity[newCapacity]
-
-		' Copy the old contents back
-		For Local pos:Int = 0 To oldObjects.Length - 1
-			Self._objects[pos] = oldObjects[pos]
-		Next
+		' Resize the internal array.
+		Self._objects = Self._objects[..newCapacity]
 
 	End Method
 


### PR DESCRIPTION
Updates `_grow` method to use BlitzMax slices instead of creating and copying arrays. Fixes issue #2.